### PR TITLE
[Feat] 네비게이션 바 및 하단 탭바 구현

### DIFF
--- a/Bubble/Bubble.xcodeproj/project.pbxproj
+++ b/Bubble/Bubble.xcodeproj/project.pbxproj
@@ -61,7 +61,6 @@
 		A2AC82A12BED5AC000C5E4D0 /* TempTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempTargetType.swift; sourceTree = "<group>"; };
 		A2AC82A52BED5AE600C5E4D0 /* TempModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempModel.swift; sourceTree = "<group>"; };
 		A2AC82A72BED5D0D00C5E4D0 /* MoyaLoggingPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoyaLoggingPlugin.swift; sourceTree = "<group>"; };
-		A2AC82AA2BED5F2B00C5E4D0 /* OSLog.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OSLog.framework; path = System/Library/Frameworks/OSLog.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -169,7 +168,6 @@
 			children = (
 				A2AC32692BECCF9B0010903A /* Bubble */,
 				A2AC32682BECCF9B0010903A /* Products */,
-				A2AC82A92BED5F2B00C5E4D0 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -228,14 +226,6 @@
 				A2AC82A52BED5AE600C5E4D0 /* TempModel.swift */,
 			);
 			path = Model;
-			sourceTree = "<group>";
-		};
-		A2AC82A92BED5F2B00C5E4D0 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				A2AC82AA2BED5F2B00C5E4D0 /* OSLog.framework */,
-			);
-			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */

--- a/Bubble/Bubble.xcodeproj/project.pbxproj
+++ b/Bubble/Bubble.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		A291B1B52BECE63E0044CB2B /* BaseCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A291B1B42BECE63E0044CB2B /* BaseCollectionViewCell.swift */; };
 		A291B1B72BECE78D0044CB2B /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = A291B1B62BECE78D0044CB2B /* .swiftlint.yml */; };
 		A29F9CB92BF273EA0030F957 /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29F9CB82BF273EA0030F957 /* TabBarController.swift */; };
+		A29F9CBB2BF27E8F0030F957 /* CALayer+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29F9CBA2BF27E8F0030F957 /* CALayer+.swift */; };
 		A2AC326B2BECCF9B0010903A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2AC326A2BECCF9B0010903A /* AppDelegate.swift */; };
 		A2AC326D2BECCF9B0010903A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2AC326C2BECCF9B0010903A /* SceneDelegate.swift */; };
 		A2AC326F2BECCF9B0010903A /* FriendsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2AC326E2BECCF9B0010903A /* FriendsViewController.swift */; };
@@ -48,6 +49,7 @@
 		A291B1B42BECE63E0044CB2B /* BaseCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCollectionViewCell.swift; sourceTree = "<group>"; };
 		A291B1B62BECE78D0044CB2B /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		A29F9CB82BF273EA0030F957 /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
+		A29F9CBA2BF27E8F0030F957 /* CALayer+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CALayer+.swift"; sourceTree = "<group>"; };
 		A2AC32672BECCF9B0010903A /* Bubble.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Bubble.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A2AC326A2BECCF9B0010903A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A2AC326C2BECCF9B0010903A /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -123,6 +125,7 @@
 				A291B1AB2BECD9280044CB2B /* UIFont+.swift */,
 				A2AC82862BED1FF700C5E4D0 /* UIView+.swift */,
 				2E2955132BEFB640001BCF22 /* UILabel+.swift */,
+				A29F9CBA2BF27E8F0030F957 /* CALayer+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -362,6 +365,7 @@
 				A2AC326D2BECCF9B0010903A /* SceneDelegate.swift in Sources */,
 				A2AC829F2BED5A2600C5E4D0 /* TempService.swift in Sources */,
 				A2AC82A22BED5AC000C5E4D0 /* TempTargetType.swift in Sources */,
+				A29F9CBB2BF27E8F0030F957 /* CALayer+.swift in Sources */,
 				A291B1B12BECD9500044CB2B /* BaseViewController.swift in Sources */,
 				A2AC829D2BED591600C5E4D0 /* Secret.swift in Sources */,
 				A2AC82872BED1FF700C5E4D0 /* UIView+.swift in Sources */,

--- a/Bubble/Bubble.xcodeproj/project.pbxproj
+++ b/Bubble/Bubble.xcodeproj/project.pbxproj
@@ -18,9 +18,10 @@
 		A291B1B32BECE5540044CB2B /* BaseTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A291B1B22BECE5540044CB2B /* BaseTableViewCell.swift */; };
 		A291B1B52BECE63E0044CB2B /* BaseCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A291B1B42BECE63E0044CB2B /* BaseCollectionViewCell.swift */; };
 		A291B1B72BECE78D0044CB2B /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = A291B1B62BECE78D0044CB2B /* .swiftlint.yml */; };
+		A29F9CB92BF273EA0030F957 /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29F9CB82BF273EA0030F957 /* TabBarController.swift */; };
 		A2AC326B2BECCF9B0010903A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2AC326A2BECCF9B0010903A /* AppDelegate.swift */; };
 		A2AC326D2BECCF9B0010903A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2AC326C2BECCF9B0010903A /* SceneDelegate.swift */; };
-		A2AC326F2BECCF9B0010903A /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2AC326E2BECCF9B0010903A /* HomeViewController.swift */; };
+		A2AC326F2BECCF9B0010903A /* FriendsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2AC326E2BECCF9B0010903A /* FriendsViewController.swift */; };
 		A2AC32742BECCF9F0010903A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A2AC32732BECCF9F0010903A /* Assets.xcassets */; };
 		A2AC32772BECCF9F0010903A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A2AC32752BECCF9F0010903A /* LaunchScreen.storyboard */; };
 		A2AC82872BED1FF700C5E4D0 /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2AC82862BED1FF700C5E4D0 /* UIView+.swift */; };
@@ -46,10 +47,11 @@
 		A291B1B22BECE5540044CB2B /* BaseTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTableViewCell.swift; sourceTree = "<group>"; };
 		A291B1B42BECE63E0044CB2B /* BaseCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCollectionViewCell.swift; sourceTree = "<group>"; };
 		A291B1B62BECE78D0044CB2B /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
+		A29F9CB82BF273EA0030F957 /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
 		A2AC32672BECCF9B0010903A /* Bubble.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Bubble.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A2AC326A2BECCF9B0010903A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A2AC326C2BECCF9B0010903A /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		A2AC326E2BECCF9B0010903A /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
+		A2AC326E2BECCF9B0010903A /* FriendsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsViewController.swift; sourceTree = "<group>"; };
 		A2AC32732BECCF9F0010903A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		A2AC32762BECCF9F0010903A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		A2AC32782BECCF9F0010903A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -110,7 +112,8 @@
 		A291B1A22BECD8DD0044CB2B /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
-				A291B1AD2BECD92E0044CB2B /* Home */,
+				A29F9CB82BF273EA0030F957 /* TabBarController.swift */,
+				A291B1AD2BECD92E0044CB2B /* Friends */,
 			);
 			path = Presentation;
 			sourceTree = "<group>";
@@ -153,12 +156,12 @@
 			path = Network;
 			sourceTree = "<group>";
 		};
-		A291B1AD2BECD92E0044CB2B /* Home */ = {
+		A291B1AD2BECD92E0044CB2B /* Friends */ = {
 			isa = PBXGroup;
 			children = (
-				A2AC326E2BECCF9B0010903A /* HomeViewController.swift */,
+				A2AC326E2BECCF9B0010903A /* FriendsViewController.swift */,
 			);
-			path = Home;
+			path = Friends;
 			sourceTree = "<group>";
 		};
 		A2AC325E2BECCF9B0010903A = {
@@ -358,8 +361,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				A291B1AA2BECD9220044CB2B /* Logger.swift in Sources */,
-				A2AC326F2BECCF9B0010903A /* HomeViewController.swift in Sources */,
+				A2AC326F2BECCF9B0010903A /* FriendsViewController.swift in Sources */,
 				A291B1AF2BECD9480044CB2B /* BaseModel.swift in Sources */,
+				A29F9CB92BF273EA0030F957 /* TabBarController.swift in Sources */,
 				A2AC326B2BECCF9B0010903A /* AppDelegate.swift in Sources */,
 				A291B1B32BECE5540044CB2B /* BaseTableViewCell.swift in Sources */,
 				A291B1B52BECE63E0044CB2B /* BaseCollectionViewCell.swift in Sources */,

--- a/Bubble/Bubble/Application/SceneDelegate.swift
+++ b/Bubble/Bubble/Application/SceneDelegate.swift
@@ -14,9 +14,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         self.window = UIWindow(windowScene: windowScene)
-
-        let navigationController = UINavigationController(rootViewController: TabBarController())
-        self.window?.rootViewController = navigationController
+        self.window?.rootViewController = TabBarController()
         self.window?.makeKeyAndVisible()
     }
 }

--- a/Bubble/Bubble/Application/SceneDelegate.swift
+++ b/Bubble/Bubble/Application/SceneDelegate.swift
@@ -15,7 +15,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         self.window = UIWindow(windowScene: windowScene)
 
-        let navigationController = UINavigationController(rootViewController: HomeViewController())
+        let navigationController = UINavigationController(rootViewController: TabBarController())
         self.window?.rootViewController = navigationController
         self.window?.makeKeyAndVisible()
     }

--- a/Bubble/Bubble/Extension/CALayer+.swift
+++ b/Bubble/Bubble/Extension/CALayer+.swift
@@ -1,0 +1,23 @@
+//
+//  CALayer+.swift
+//  Bubble
+//
+//  Created by 서은수 on 5/14/24.
+//
+
+import UIKit
+
+extension CALayer {
+    func applyShadow(
+        color: UIColor = .black,
+        alpha: Float = 0.05,
+        x: CGFloat = 0,
+        y: CGFloat = -4,
+        blur: CGFloat = 10
+    ) {
+        shadowColor = color.cgColor
+        shadowOpacity = alpha
+        shadowOffset = CGSize(width: x, height: y)
+        shadowRadius = blur / 2.0
+    }
+}

--- a/Bubble/Bubble/Extension/UIFont+.swift
+++ b/Bubble/Bubble/Extension/UIFont+.swift
@@ -73,8 +73,6 @@ extension UIFont {
         case .body2:
             size = 10
             fontName = FontName.medium.rawValue
-        default:
-            fatalError("Invalid name")
         }
         
         return UIFont(name: fontName, size: size)

--- a/Bubble/Bubble/Presentation/Friends/FriendsViewController.swift
+++ b/Bubble/Bubble/Presentation/Friends/FriendsViewController.swift
@@ -7,26 +7,76 @@
 
 import UIKit
 
-class FriendsViewController: BaseViewController {
+enum NavigationTitleName: String {
+    case friends = "FRIENDS"
+    case more = "MORE"
+}
 
+final class FriendsViewController: BaseViewController {
+    
     // MARK: - Property
-
+    
     // MARK: - Component
 
-    // MARK: - Life Cycle
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        
+    private let storeBarButton = UIBarButtonItem(image: .iconStore, style: .plain, target: nil, action: nil).then {
+        $0.tintColor = .black
     }
-
+    
+    private let searchBarButton = UIBarButtonItem(image: .iconSearch, style: .plain, target: nil, action: nil).then {
+        $0.tintColor = .black
+    }
+    
+    private var scrollView = UIScrollView().then {
+        $0.backgroundColor = .white
+    }
+        
     // MARK: - Set UI
+    
+    override func setLayout() {
+        /// scrollView의 경우 스크롤 시 네비게이션 바 확인하기 위한 테스트용
+        view.addSubview(scrollView)
+        
+        scrollView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        scrollView.contentSize = CGSize(width: view.frame.width, height: 2000)
+    }
+    
+    override func setStyle() {
+        navigationItem.title = NavigationTitleName.friends.rawValue
 
+        navigationController?.navigationBar.prefersLargeTitles = true
+        navigationItem.largeTitleDisplayMode = .always
+        
+        let navigationBarAppearance = UINavigationBarAppearance().then {
+            $0.backgroundColor = .white
+            $0.titlePositionAdjustment = .init(
+                horizontal: -CGFloat.greatestFiniteMagnitude,
+                vertical: 0
+            )
+            $0.largeTitleTextAttributes = [.font: UIFont.appleSDGothicNeoFont(for: .headline1) ?? UIFont()]
+            $0.titleTextAttributes = [.font: UIFont.appleSDGothicNeoFont(for: .headline3) ?? UIFont()]
+//            $0.shadowImage = UIImage()
+//            $0.backgroundImage = UIImage()
+        }
+        navigationItem.scrollEdgeAppearance = navigationBarAppearance
+        navigationItem.compactAppearance = navigationBarAppearance
+        navigationItem.standardAppearance = navigationBarAppearance
+        
+        navigationItem.setRightBarButtonItems([storeBarButton, searchBarButton], animated: true)
+        navigationItem.rightBarButtonItem?.tintColor = .black
+        
+//        self.navigationController?.navigationBar.shadowImage = UIImage()
+//        UINavigationBar.appearance().shadowImage = UIImage()
+//        UINavigationBar.appearance().setBackgroundImage(UIImage(), for: .default)
+    }
+    
     // MARK: - Helper
-
+    
     // MARK: - Action
-
+    
     // MARK: - Extension
-
+    
     // MARK: - Delegate
 }

--- a/Bubble/Bubble/Presentation/Friends/FriendsViewController.swift
+++ b/Bubble/Bubble/Presentation/Friends/FriendsViewController.swift
@@ -1,5 +1,5 @@
 //
-//  HomeViewController.swift
+//  FriendsViewController.swift
 //  Bubble
 //
 //  Created by 서은수 on 5/9/24.
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class HomeViewController: BaseViewController {
+class FriendsViewController: BaseViewController {
 
     // MARK: - Property
 
@@ -17,6 +17,7 @@ class HomeViewController: BaseViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        
     }
 
     // MARK: - Set UI

--- a/Bubble/Bubble/Presentation/TabBarController.swift
+++ b/Bubble/Bubble/Presentation/TabBarController.swift
@@ -7,6 +7,9 @@
 
 import UIKit
 
+import SnapKit
+import Then
+
 enum TabBarDefaultImgName: String {
     case friends = "icon_tabPersonDefault"
     case chat = "icon_tabChatDefault"
@@ -19,21 +22,63 @@ enum TabBarSelectedImgName: String {
     case more = "icon_tabMoreSelected"
 }
 
-/// 하단 탭바
 final class TabBarController: UITabBarController {
     
+    // MARK: - Component
+    
+    let roundedBorderView = UIView().then {
+        $0.layer.masksToBounds = true
+        $0.layer.cornerRadius = 10
+        $0.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+        $0.layer.borderColor = UIColor.gray100.cgColor
+        $0.layer.borderWidth = 1
+        $0.isUserInteractionEnabled = false
+    }
+    
+    let whiteCoverView = UIView().then {
+        $0.backgroundColor = .white
+        $0.isUserInteractionEnabled = false
+    }
+
     // MARK: - Life Cycle
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        createDefaultTabBar()
+        setLayout()
+        setStyle()
+        setTabBar()
+    }
+    
+    // MARK: - Set UI
+    
+    private func setLayout() {
+        self.tabBar.addSubviews(roundedBorderView, whiteCoverView)
+        
+        roundedBorderView.snp.makeConstraints {
+            $0.top.leading.trailing.equalToSuperview()
+            $0.height.equalTo(50)
+        }
+        whiteCoverView.snp.makeConstraints {
+            $0.top.equalTo(roundedBorderView.snp.bottom).offset(-1)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(1)
+        }
+    }
+
+    private func setStyle() {
+        UITabBar.appearance().shadowImage = UIImage()
+        UITabBar.appearance().backgroundImage = UIImage()
+        UITabBar.appearance().backgroundColor = UIColor.white
+        
+        tabBar.layer.cornerRadius = 10
+        tabBar.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+        tabBar.layer.applyShadow()
     }
     
     // MARK: - Helpers
     
-    /// 기본 하단 탭바 생성
-    private func createDefaultTabBar() {
+    private func setTabBar() {
         let friendsVC = FriendsViewController()
         configTabBar(
             tabDefaultImgName: .friends,
@@ -58,16 +103,17 @@ final class TabBarController: UITabBarController {
         self.viewControllers = [friendsVC, chatVC, moreVC]
     }
     
-    /// 탭바 설정
     private func configTabBar(
         tabDefaultImgName: TabBarDefaultImgName,
         tabSelectedImgName: TabBarSelectedImgName,
         viewController: UIViewController
     ) {
-        viewController.tabBarItem = UITabBarItem(
+        let tabBarItem = UITabBarItem(
             title: nil,
             image: .init(named: tabDefaultImgName.rawValue)?.withRenderingMode(.alwaysOriginal),
             selectedImage: .init(named: tabSelectedImgName.rawValue)?.withRenderingMode(.alwaysOriginal)
         )
+        tabBarItem.imageInsets = UIEdgeInsets(top: 10, left: 0, bottom: -10, right: 0)
+        viewController.tabBarItem = tabBarItem
     }
 }

--- a/Bubble/Bubble/Presentation/TabBarController.swift
+++ b/Bubble/Bubble/Presentation/TabBarController.swift
@@ -79,28 +79,31 @@ final class TabBarController: UITabBarController {
     // MARK: - Helpers
     
     private func setTabBar() {
-        let friendsVC = FriendsViewController()
+        let friendsNavigationController = UINavigationController(rootViewController: FriendsViewController())
         configTabBar(
             tabDefaultImgName: .friends,
             tabSelectedImgName: .friends,
-            viewController: friendsVC
+            viewController: friendsNavigationController
         )
         // TODO: - 뷰컨 생성 후 할당
-        let chatVC = FriendsViewController()
+        let chatViewController = UIViewController().then {
+            $0.view.backgroundColor = .white
+        }
+        let chatNavigationController = UINavigationController(rootViewController: chatViewController)
         configTabBar(
             tabDefaultImgName: .chat,
             tabSelectedImgName: .chat,
-            viewController: chatVC
+            viewController: chatNavigationController
         )
         // TODO: - 뷰컨 생성 후 할당
-        let moreVC = FriendsViewController()
+        let moreNavigationController = UINavigationController(rootViewController: FriendsViewController())
         configTabBar(
             tabDefaultImgName: .more,
             tabSelectedImgName: .more,
-            viewController: moreVC
+            viewController: moreNavigationController
         )
         
-        self.viewControllers = [friendsVC, chatVC, moreVC]
+        self.viewControllers = [friendsNavigationController, chatNavigationController, moreNavigationController]
     }
     
     private func configTabBar(

--- a/Bubble/Bubble/Presentation/TabBarController.swift
+++ b/Bubble/Bubble/Presentation/TabBarController.swift
@@ -1,0 +1,73 @@
+//
+//  TabBarController.swift
+//  Bubble
+//
+//  Created by 서은수 on 5/14/24.
+//
+
+import UIKit
+
+enum TabBarDefaultImgName: String {
+    case friends = "icon_tabPersonDefault"
+    case chat = "icon_tabChatDefault"
+    case more = "icon_tabMoreDefault"
+}
+
+enum TabBarSelectedImgName: String {
+    case friends = "icon_tabPersonSelected"
+    case chat = "icon_tabChatSelected"
+    case more = "icon_tabMoreSelected"
+}
+
+/// 하단 탭바
+final class TabBarController: UITabBarController {
+    
+    // MARK: - Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        createDefaultTabBar()
+    }
+    
+    // MARK: - Helpers
+    
+    /// 기본 하단 탭바 생성
+    private func createDefaultTabBar() {
+        let friendsVC = FriendsViewController()
+        configTabBar(
+            tabDefaultImgName: .friends,
+            tabSelectedImgName: .friends,
+            viewController: friendsVC
+        )
+        // TODO: - 뷰컨 생성 후 할당
+        let chatVC = FriendsViewController()
+        configTabBar(
+            tabDefaultImgName: .chat,
+            tabSelectedImgName: .chat,
+            viewController: chatVC
+        )
+        // TODO: - 뷰컨 생성 후 할당
+        let moreVC = FriendsViewController()
+        configTabBar(
+            tabDefaultImgName: .more,
+            tabSelectedImgName: .more,
+            viewController: moreVC
+        )
+        
+        self.viewControllers = [friendsVC, chatVC, moreVC]
+    }
+    
+    /// 탭바 설정
+    private func configTabBar(
+        tabDefaultImgName: TabBarDefaultImgName,
+        tabSelectedImgName: TabBarSelectedImgName,
+        viewController: UIViewController
+    ) {
+        viewController.tabBarItem = UITabBarItem(
+            title: nil,
+            image: .init(named: tabDefaultImgName.rawValue)?.withRenderingMode(.alwaysOriginal),
+            selectedImage: .init(named: tabSelectedImgName.rawValue)?.withRenderingMode(.alwaysOriginal)
+        )
+    }
+}


### PR DESCRIPTION
## 🔍 What is the PR?
버블 앱의 기본 네비게이션 바 및 하단 탭바를 구현하였습니다.
    
## 📸 Screenshot 
|![Simulator Screen Recording - iPhone 13 Pro - 2024-05-14 at 11 11 07](https://github.com/NOW-SOPT-APP6-BUBBLE/bubble-iOS/assets/87434861/9a08559a-1cc4-4643-85ed-7e32d3c64ee4)|
|---|
    
## 📍 PR Point 
### 1. 하단 탭바 커스텀    
<img width="500" alt="스크린샷 2024-05-14 오전 11 16 10" src="https://github.com/NOW-SOPT-APP6-BUBBLE/bubble-iOS/assets/87434861/c6b4cd9e-757d-47dc-9f99-c4dd76265593">  

그냥 기본 하단 탭바인 줄 알고 작업을 시작했었으나 피그마에서 자세히 보니까 그림자가 있는 거예요? 근데 더 자세히 보니까 양쪽 상단 끝이 둥글고... 더 자세히 보니까 탭바의 상단, 왼쪽, 오른쪽 영역에... gray border가 존재했었습니다.

> TabBarController의 setStyle 함수
````
private func setStyle() {
    UITabBar.appearance().shadowImage = UIImage()
    UITabBar.appearance().backgroundImage = UIImage()
    UITabBar.appearance().backgroundColor = UIColor.white
        
    tabBar.layer.cornerRadius = 10
    tabBar.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
    tabBar.layer.applyShadow()
}
````
- 탭바의 기본 그림자를 제거하고 커스텀 그림자를 추가합니다.
- cornerRadius를 상단의 양쪽 끝에 적용합니다.
> CALayer+의 applyShadow 함수
````
extension CALayer {
    func applyShadow(
        color: UIColor = .black,
        alpha: Float = 0.05,
        x: CGFloat = 0,
        y: CGFloat = -4,
        blur: CGFloat = 10
    ) {
        shadowColor = color.cgColor
        shadowOpacity = alpha
        shadowOffset = CGSize(width: x, height: y)
        shadowRadius = blur / 2.0
    }
}
````
- CALayer를 확장하여 함수의 파라미터로 받은 값에 따라 그림자를 layer에 적용합니다.

gray border의 경우, 일반적으로 TabBar의 border로 바로 설정하는 경우와 달리 좌우에도 border가 보여야 해서 UIView를 통해 구현하여 TabBar의 서브뷰로 추가하였습니다.
> TabBarController.swift
```
let roundedBorderView = UIView().then {
    $0.layer.masksToBounds = true
    $0.layer.cornerRadius = 10
    $0.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
    $0.layer.borderColor = UIColor.gray100.cgColor
    $0.layer.borderWidth = 1
    $0.isUserInteractionEnabled = false
}

let whiteCoverView = UIView().then {
    $0.backgroundColor = .white
    $0.isUserInteractionEnabled = false
}
```
```
private func setLayout() {
    self.tabBar.addSubviews(roundedBorderView, whiteCoverView)
    
    roundedBorderView.snp.makeConstraints {
        $0.top.leading.trailing.equalToSuperview()
        $0.height.equalTo(50)
    }
    whiteCoverView.snp.makeConstraints {
        $0.top.equalTo(roundedBorderView.snp.bottom).offset(-1)
        $0.leading.trailing.equalToSuperview()
        $0.height.equalTo(1)
    }
}
```
- roundedBorderView을 통해 상하좌우 gray border를 추가합니다.
- height 1인 whiteCoverView를 사용하여 하단 gray border를 가립니다.

### 2. 네비게이션 바 커스텀
스크롤 시 타이틀뷰가 왼쪽 정렬이 되어야 하는데, 기본은 중앙 정렬이라 아래와 같은 코드를 통해 구현하였습니다.
> FriendsViewController의 setStyle 함수
```
let navigationBarAppearance = UINavigationBarAppearance().then {
    $0.backgroundColor = .white
    $0.titlePositionAdjustment = .init(
        horizontal: -CGFloat.greatestFiniteMagnitude,
        vertical: 0
    )
    $0.largeTitleTextAttributes = [.font: UIFont.appleSDGothicNeoFont(for: .headline1) ?? UIFont()]
    $0.titleTextAttributes = [.font: UIFont.appleSDGothicNeoFont(for: .headline3) ?? UIFont()]
}
navigationItem.scrollEdgeAppearance = navigationBarAppearance
navigationItem.compactAppearance = navigationBarAppearance
navigationItem.standardAppearance = navigationBarAppearance
```
- horizontal 값을 음수 중 최소값으로 주어 맨 왼쪽으로 정렬시킵니다.

## 📢 Notices
- 더보기 페이지 구현하신 후에 TabBarController의 setTabBar 함수에 MoreViewController()를 넣어서 연결해주세요!
- 말씀 드린 이슈로 인해 아직 네비게이션 bottom line을 제거하지 못했는데, 추후 구현해서 올리도록 하겠습니다!
    
## 🙏 To Reviewers 
- gray border 관련해서 해당 방법이 최고의 솔루션이라고 생각하지 않기 때문에 더 좋은 방법이 있다면 공유 부탁드립니다!
    
## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 1000줄을 넘지 않는가?    

## 💭 Related Issues 
- Resolved: #6 