### PR TITLE
[Feat] 네비게이션 하단 밑줄 지우기

### DIFF
--- a/Bubble/Bubble.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Bubble/Bubble.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,4 @@
 {
-  "originHash" : "038fc281c921b410bdeab49776a27abccbd8a65614df2d1393549308d5b9275d",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -65,5 +64,5 @@
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/Bubble/Bubble/Presentation/Friends/FriendsViewController.swift
+++ b/Bubble/Bubble/Presentation/Friends/FriendsViewController.swift
@@ -68,7 +68,6 @@ final class FriendsViewController: BaseViewController {
             $0.largeTitleTextAttributes = [.font: UIFont.appleSDGothicNeoFont(for: .headline1) ?? UIFont()]
             $0.titleTextAttributes = [.font: UIFont.appleSDGothicNeoFont(for: .headline3) ?? UIFont()]
         }
-        navigationItem.compactAppearance = navigationBarAppearance
         navigationItem.standardAppearance = navigationBarAppearance
         
         navigationItem.setRightBarButtonItems([storeBarButton, searchBarButton], animated: true)

--- a/Bubble/Bubble/Presentation/Friends/FriendsViewController.swift
+++ b/Bubble/Bubble/Presentation/Friends/FriendsViewController.swift
@@ -67,19 +67,12 @@ final class FriendsViewController: BaseViewController {
             )
             $0.largeTitleTextAttributes = [.font: UIFont.appleSDGothicNeoFont(for: .headline1) ?? UIFont()]
             $0.titleTextAttributes = [.font: UIFont.appleSDGothicNeoFont(for: .headline3) ?? UIFont()]
-//            $0.shadowImage = UIImage()
-//            $0.backgroundImage = UIImage()
         }
-        navigationItem.scrollEdgeAppearance = navigationBarAppearance
         navigationItem.compactAppearance = navigationBarAppearance
         navigationItem.standardAppearance = navigationBarAppearance
         
         navigationItem.setRightBarButtonItems([storeBarButton, searchBarButton], animated: true)
         navigationItem.rightBarButtonItem?.tintColor = .black
-        
-//        self.navigationController?.navigationBar.shadowImage = UIImage()
-//        UINavigationBar.appearance().shadowImage = UIImage()
-//        UINavigationBar.appearance().setBackgroundImage(UIImage(), for: .default)
     }
     
     // MARK: - Life Cycle


### PR DESCRIPTION
## 🔍 What is the PR?
피그마대로라면 스크롤을 하지 않았을 때에는 네비게이션 하단에 밑줄이 없어야 되는데 계속 밑줄이 있었던 문제가 있었습니다.
이를 해결하였습니다!
    
## 📸 Screenshot 
|![Simulator Screen Recording - iPhone 13 Pro - 2024-05-22 at 21 50 08](https://github.com/NOW-SOPT-APP6-BUBBLE/bubble-iOS/assets/87434861/0557a7b4-8f79-473d-8545-4e3039d3d336)|
|--|    
    
## 📍 PR Point 
`scrollEdgeAppearance`를 `navigationBarAppearance` 값으로 설정하는 코드를 제거했더니 밑줄이 사라졌습니다...! (황당티비)
그리고 코드를 살펴보니 `compactAppearance` 값도 굳이 설정할 필요가 없길래(= 없애도 똑같이 잘 나오길래) 삭제해주었습니다.
우린 기본 네비게이션 스타일을 사용하기 때문에 그냥 `standardAppearance` 값만 잘 설정해주면 되는 것!

## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 1000줄을 넘지 않는가?    

## 💭 Related Issues 
- Resolved: #26 