### PR TITLE
[Fix] 드롭다운 버튼 클릭 시 에러 해결

### DIFF
--- a/Bubble/Bubble.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Bubble/Bubble.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,4 @@
 {
-  "originHash" : "a33fc211d3e1d3a7fbf825eb746f29ca39abad4695e8f9a59eaee327217e4e09",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -65,5 +64,5 @@
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/Bubble/Bubble/Application/SceneDelegate.swift
+++ b/Bubble/Bubble/Application/SceneDelegate.swift
@@ -14,7 +14,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         self.window = UIWindow(windowScene: windowScene)
-        self.window?.rootViewController = StoreViewController()
+        self.window?.rootViewController = TabBarController()
         self.window?.makeKeyAndVisible()
     }
 }

--- a/Bubble/Bubble/Network/Service/ArtistMembersService.swift
+++ b/Bubble/Bubble/Network/Service/ArtistMembersService.swift
@@ -67,6 +67,25 @@ extension ArtistMembersService {
         }
     }
     
+    func registerArtistSubs(
+        memberId: String, artistMemberId: Int,
+        completion: @escaping (NetworkResult<Any>) -> Void
+    ) {
+        artistMemberProvider.request(
+            .registerArtistSubs(memberId: memberId, artistMemberId: artistMemberId)) { result in
+            switch result {
+            case .success(let response):
+                print(response)
+                let statusCode = response.statusCode
+                let data = response.data
+                let networkResult = self.judgeStatus(by: statusCode, data, EmptyResultModel.self)
+                completion(networkResult)
+            case .failure:
+                completion(.networkFail)
+            }
+        }
+    }
+    
     private func judgeStatus<T: Codable>(by statusCode: Int, _ data: Data, _ object: T.Type) -> NetworkResult<Any> {
         switch statusCode {
         case 200..<205:

--- a/Bubble/Bubble/Network/Service/ArtistsServeice.swift
+++ b/Bubble/Bubble/Network/Service/ArtistsServeice.swift
@@ -17,7 +17,7 @@ final class ArtistsServeice {
 }
 
 extension ArtistsServeice {
-    func getStoreDetail(memberId: String, artistId: String, completion: @escaping (NetworkResult<Any>) -> Void) {
+    func getStoreDetail(memberId: String, artistId: Int, completion: @escaping (NetworkResult<Any>) -> Void) {
         artistsProvider.request(.getStoreDetail(memberId: memberId, artistId: artistId)) { result in
             switch result {
             case .success(let response):

--- a/Bubble/Bubble/Network/TargetType/ArtistMembersTargetType.swift
+++ b/Bubble/Bubble/Network/TargetType/ArtistMembersTargetType.swift
@@ -13,6 +13,7 @@ enum ArtistMembersTargetType {
     case fetchArtistList(memberId: String)
     case fetchArtistProfile(request: ArtistProfileRequest)
     case deleteArtistSubs(memberId: String, artistMemberId: Int)
+    case registerArtistSubs(memberId: String, artistMemberId: Int)
 }
 
 extension ArtistMembersTargetType: TargetType {
@@ -24,11 +25,11 @@ extension ArtistMembersTargetType: TargetType {
         switch self {
         case .fetchArtistList:
             return "/api/v1/artists/artist-members"
-            
         case .fetchArtistProfile(let request):
             return "/api/v1/artists/artist-members/\(request.artistMemberId)"
-            
         case .deleteArtistSubs(_, artistMemberId: let artistMemberId):
+            return "/api/v1/artists/artist-members/friend/\(artistMemberId)"
+        case .registerArtistSubs(_, artistMemberId: let artistMemberId):
             return "/api/v1/artists/artist-members/friend/\(artistMemberId)"
         }
     }
@@ -39,12 +40,14 @@ extension ArtistMembersTargetType: TargetType {
             return .get
         case .deleteArtistSubs:
             return .delete
+        case .registerArtistSubs:
+            return .post
         }
     }
     
     var task: Moya.Task {
         switch self {
-        case .fetchArtistList, .fetchArtistProfile, .deleteArtistSubs:
+        case .fetchArtistList, .fetchArtistProfile, .deleteArtistSubs, .registerArtistSubs:
             return .requestPlain
         }
     }
@@ -60,6 +63,8 @@ extension ArtistMembersTargetType: TargetType {
         case .deleteArtistSubs(memberId: let memberId, artistMemberId: _):
             return ["Content-Type": "application/json",
                     "memberId": memberId]
+        case .registerArtistSubs(memberId: let memberId, artistMemberId: _):
+            return ["memberId": memberId]
         }
     }
 }

--- a/Bubble/Bubble/Network/TargetType/ArtistsTargetType.swift
+++ b/Bubble/Bubble/Network/TargetType/ArtistsTargetType.swift
@@ -10,7 +10,7 @@ import Foundation
 import Moya
 
 enum ArtistsTargetType {
-    case getStoreDetail(memberId: String, artistId: String)
+    case getStoreDetail(memberId: String, artistId: Int)
     case getStore(memberId: String)
 }
 

--- a/Bubble/Bubble/Presentation/Friends/Cell/FriendsHeaderView.swift
+++ b/Bubble/Bubble/Presentation/Friends/Cell/FriendsHeaderView.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-protocol DropDownDelegate {
+protocol DropDownDelegate: AnyObject {
     func dropDownCells(section: Int)
 }
 
@@ -28,7 +28,7 @@ final class FriendsHeaderView: UITableViewHeaderFooterView {
     }
     
     lazy var dropDownButton = UIButton().then {
-        $0.setImage(.iconUnfold, for: .normal)
+        $0.setImage(.iconFold, for: .normal)
         $0.addTarget(self, action: #selector(dropDownButtonDidTap), for: .touchUpInside)
     }
     
@@ -49,7 +49,7 @@ final class FriendsHeaderView: UITableViewHeaderFooterView {
     override func prepareForReuse() {
         super.prepareForReuse()
         
-        dropDownButton.setImage(.iconUnfold, for: .normal)
+        dropDownButton.setImage(.iconFold, for: .normal)
     }
     
     // MARK: - Set UI
@@ -69,6 +69,7 @@ final class FriendsHeaderView: UITableViewHeaderFooterView {
         }
         
         dropDownButton.snp.makeConstraints {
+            $0.size.equalTo(24)
             $0.centerY.equalToSuperview()
             $0.trailing.equalToSuperview().inset(16)
         }

--- a/Bubble/Bubble/Presentation/Friends/Cell/FriendsTableViewCell.swift
+++ b/Bubble/Bubble/Presentation/Friends/Cell/FriendsTableViewCell.swift
@@ -36,6 +36,7 @@ final class FriendsTableViewCell: BaseTableViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         
+        isHidden = false
         profileImageView.image = .iconProfile
         nameLabel.text = "언니"
         oneSentenceLabel.text = ""

--- a/Bubble/Bubble/Presentation/Friends/Cell/FriendsTableViewCell.swift
+++ b/Bubble/Bubble/Presentation/Friends/Cell/FriendsTableViewCell.swift
@@ -36,7 +36,6 @@ final class FriendsTableViewCell: BaseTableViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         
-        isHidden = false
         profileImageView.image = .iconProfile
         nameLabel.text = "언니"
         oneSentenceLabel.text = ""

--- a/Bubble/Bubble/Presentation/Friends/Model/ArtistListModel.swift
+++ b/Bubble/Bubble/Presentation/Friends/Model/ArtistListModel.swift
@@ -18,3 +18,13 @@ struct ArtistListModel: Codable {
     var imageURL: String
     var introduction: String?
 }
+
+struct ArtistListCellData {
+    var isExpanded: Bool
+    var dataModel: [ArtistListModel]
+    
+    init(isExpanded: Bool = true, dataModel: [ArtistListModel] = []) {
+        self.isExpanded = isExpanded
+        self.dataModel = dataModel
+    }
+}

--- a/Bubble/Bubble/Presentation/Friends/ProfileViewController.swift
+++ b/Bubble/Bubble/Presentation/Friends/ProfileViewController.swift
@@ -195,6 +195,11 @@ final class ProfileViewController: BaseViewController {
         if data.status == 200 { self.isStar = false }
     }
     
+    private func onRegisterSuccess(_ data: EmptyResultModel?) {
+        guard let data = data else { return }
+        if data.status == 201 { self.isStar = true }
+    }
+    
     // MARK: - Action
     
     @objc private func xButtonDidTap() {
@@ -215,9 +220,10 @@ final class ProfileViewController: BaseViewController {
             }
         ):(
             /// 즐겨찾기 등록
-            // MARK: Todo - 즐겨찾기 등록 함수 작성해주세요
+            ArtistMembersService.shared.registerArtistSubs(memberId: memberId, artistMemberId: artistMemberId) { res in
+                res.defineNetworkResult(res) {data in self.onRegisterSuccess(data as? EmptyResultModel)}
+            }
         )
-        
         starButton.setImage(isStar ? .iconEmptyStar : .iconStar, for: .normal)
     }
 }

--- a/Bubble/Bubble/Presentation/Store/StoreViewController.swift
+++ b/Bubble/Bubble/Presentation/Store/StoreViewController.swift
@@ -212,6 +212,14 @@ extension StoreViewController: UICollectionViewDataSource {
 
 extension StoreViewController: UICollectionViewDelegate {
     
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+            print("didselect")
+            let artist = storeArtists[indexPath.item]
+            let detailVC = StoreDetailViewController()
+            detailVC.artistId = artist.artistId
+            self.navigationController?.pushViewController(detailVC, animated: true)
+    }
+    
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         let maxOffsetY = scrollView.contentSize.height - scrollView.frame.size.height
         if scrollView.contentOffset.y > maxOffsetY {

--- a/Bubble/Bubble/Presentation/StoreDetail/StoreDetailViewController.swift
+++ b/Bubble/Bubble/Presentation/StoreDetail/StoreDetailViewController.swift
@@ -11,6 +11,8 @@ final class StoreDetailViewController: BaseViewController {
     
     // MARK: - Property
     
+    var artistId: Int = 0
+    
     // MARK: - Component
     
     private var scrollView = UIScrollView()
@@ -49,14 +51,47 @@ final class StoreDetailViewController: BaseViewController {
         
         $0.addTarget(self, action: #selector(buyButtonDidTap), for: .touchUpInside)
     }
+    
+    private lazy var closeButton = UIBarButtonItem(
+        image: .iconClose,
+        style: .plain,
+        target: self,
+        action: #selector(closeButtonDidTap)
+    ).then {
+        $0.tintColor = .black
+    }
+    
+    private lazy var backButton = UIBarButtonItem(
+        image: .iconBack,
+        style: .plain,
+        target: self,
+        action: #selector(backButtonDidTap)
+    ).then {
+        $0.tintColor = .black
+    }
+    
+    private let storeDetailNavigationBarTitle = UILabel().then {
+        $0.attributedText = UILabel.createAttributedText(for: .headline3, withText: "bubble")
+        $0.textAlignment = .center
+    }
+    
     // MARK: - init
     
     // MARK: - Life Cycle
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
         fetchStoreDetail()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.tabBarController?.tabBar.isHidden = true
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        self.tabBarController?.tabBar.isHidden = false
     }
     
     // MARK: - Set UI
@@ -106,7 +141,13 @@ final class StoreDetailViewController: BaseViewController {
     }
     
     override func setStyle() {
-        view.backgroundColor = .gray700
+        view.backgroundColor = .white
+        scrollView.backgroundColor = .gray700
+        navigationItem.titleView = storeDetailNavigationBarTitle
+        navigationItem.setRightBarButtonItems([closeButton], animated: true)
+        navigationItem.setLeftBarButtonItems([backButton], animated: true)
+        navigationItem.hidesBackButton = true
+        navigationItem.largeTitleDisplayMode = .never
     }
     
     // MARK: - Helper
@@ -118,7 +159,7 @@ final class StoreDetailViewController: BaseViewController {
     
     private func fetchStoreDetail() {
         ArtistsServeice.shared.getStoreDetail(
-            memberId: "1", artistId: "1"
+            memberId: "1", artistId: self.artistId
         ) { res in
             switch res {
             case .success(let data):
@@ -140,6 +181,23 @@ final class StoreDetailViewController: BaseViewController {
             case .networkFail:
                 print("네트워크 오류입니다")
             }
+        }
+    }
+    
+    @objc private func backButtonDidTap() {
+        self.navigationController?.popViewController(animated: true)
+    }
+    
+    @objc private func closeButtonDidTap() {
+        guard let viewControllers = self.navigationController?.viewControllers else {
+            return
+        }
+        
+        if viewControllers.count >= 3 {
+            let targetViewController = viewControllers[viewControllers.count - 3]
+            self.navigationController?.popToViewController(targetViewController, animated: true)
+        } else {
+            self.navigationController?.popViewController(animated: true)
         }
     }
     

--- a/Bubble/Bubble/Presentation/TabBarController.swift
+++ b/Bubble/Bubble/Presentation/TabBarController.swift
@@ -85,7 +85,7 @@ final class TabBarController: UITabBarController {
             tabSelectedImgName: .friends,
             viewController: friendsNavigationController
         )
-        // TODO: - 뷰컨 생성 후 할당
+
         let chatViewController = UIViewController().then {
             $0.view.backgroundColor = .white
         }


### PR DESCRIPTION
## 🔍 What is the PR?
즐겨찾기 섹션에 데이터가 추가된 이후로 (= 섹션 0, 1번 모두에 셀 데이터가 존재하기 시작한 이후로) 드롭다운 버튼 클릭 시 앱이 죽는 에러가 있었는데, 이를 해결하였습니다.
데이터 싱크에 대한 에러였음!
    
## 📸 Screenshot 
|![Simulator Screen Recording - iPhone 13 Pro - 2024-05-24 at 21 23 49](https://github.com/NOW-SOPT-APP6-BUBBLE/bubble-iOS/assets/87434861/180a6b57-48bd-460d-bfcf-fd75cd924b60)|
|--|
    
## 📍 PR Point 
### 1. Fix: 드롭다운 버튼 클릭 시 알 수 없는 앱 크래시 해결
특정 섹션은 업데이트를 해주고, 다른 섹션은 그대로 둔다면 전체 sync가 안 맞아서 앱이 죽을 수 있다고 합니다!
그래서 해결 방법은
1) 전체 테이블뷰를 싹 다 새로 그리거나
2) 특정 섹션에 대한 업데이트를 진행할 때 update 구문 안에서 진행하기

두 가지의 방법이 있는데 2번을 택하여서 구현하였습니다.
> FriendsViewController.swift
```
self.friendsTableView.beginUpdates()
self.friendsTableView.reloadSections(.init(1...2), with: .fade)
self.friendsTableView.endUpdates()
```

### 2. Refactor: isDropDownArray 사용하지 않고 데이터 모델 안에 isExpanded 변수로 처리
이것이 의미 상으로 더 나은 방식인 것 같아서 `isExpanded` 변수와 리스트 모델 값을 가지고 있는 `ArtistListCellData` 구조체를 추가하였습니다!
> ArtistListModel.swift
```
struct ArtistListCellData {
    var isExpanded: Bool
    var dataModel: [ArtistListModel]
    
    init(isExpanded: Bool = true, dataModel: [ArtistListModel] = []) {
        self.isExpanded = isExpanded
        self.dataModel = dataModel
    }
}
```

### 3. Fix: 아티스트 상세 프로필 화면에서 즐찾 여부 변경 시 리스트에 바로 업데이트 되도록 호출 시점 변경
아티스트 상세 프로필 화면에서 즐겨찾기 버튼 클릭하고 X 버튼 눌러서 아티스트 목록 화면으로 왔을 때,
해당 변경사항을 목록에 바로 반영되도록
API로 아티스트 목록을 불러오는 시점을 `viewDidLoad`에서 `viewWillAppear`로 변경하였습니다.
> FriendsViewController.swift
```
override func viewWillAppear(_ animated: Bool) {
    super.viewWillAppear(animated)

    fetchArtistList()
}
```

## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 1000줄을 넘지 않는가?    

## 💭 Related Issues 
- Resolved: #36 